### PR TITLE
Pass bot names as player_name in game info

### DIFF
--- a/proxy_controller/src/websocket/player.rs
+++ b/proxy_controller/src/websocket/player.rs
@@ -388,7 +388,8 @@ impl Player {
                     if response.has_game_info() {
                         for pi in &mut response.mut_game_info().player_info {
                             if pi.player_id() != r_vars.player_id() {
-                                pi.player_name = Some(config.players[&player_num.other_player()].name.clone());
+                                pi.player_name =
+                                    Some(config.players[&player_num.other_player()].name.clone());
                                 pi.race_actual = pi.race_requested;
                             } else {
                                 pi.player_name = Some(config.players[&player_num].name.clone());

--- a/proxy_controller/src/websocket/player.rs
+++ b/proxy_controller/src/websocket/player.rs
@@ -388,7 +388,10 @@ impl Player {
                     if response.has_game_info() {
                         for pi in &mut response.mut_game_info().player_info {
                             if pi.player_id() != r_vars.player_id() {
+                                pi.player_name = Some(config.players[&player_num.other_player()].name.clone());
                                 pi.race_actual = pi.race_requested;
+                            } else {
+                                pi.player_name = Some(config.players[&player_num].name.clone());
                             }
                         }
                     }


### PR DESCRIPTION
Setting the name as part of the JoinGame request doesn't seem enough for the game to include it in the GameInfo data.
Here the proxy will set the names of both players at the time it sets the actual race of the opponent to be its requested race. This is done every time GameInfo is requested by a bot.