### PR TITLE
Release action to set release version in config.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           cp -vr kubernetes ${{ runner.temp }}
           echo 'Setting version ${{ steps.version.outputs.tag }} in deployment descriptors'
+          sed -i -e 's|0.0.0|${{ steps.version.outputs.tag }}|g' ${{ runner.temp }}/kubernetes/configmap.yaml
           sed -i -e 's|aiarena/k8s-controller|aiarena/k8s-controller:${{ steps.version.outputs.tag }}|g' ${{ runner.temp }}/kubernetes/deployment.yaml
           git fetch
           git switch kubernetes

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -9,6 +9,7 @@ metadata:
   namespace: arenaclients
 data:
   config.toml: |-
+    VERSION = "0.0.0"
     OLD_MATCH_DELETE_AFTER_MINUTES = 10
     JOB_PREFIX= "prod"
     WEBSITE_URL= "https://aiarena.net"


### PR DESCRIPTION
Release action missed setting the new version in config.toml which meant that k8s-controller will run at the new version but it will start all jobs for matches with Docker images at version 0.6.10. The change makes sure the new version is set in config.toml. k82-controller is already prepared to read it from there and apply it to the deployment template for the job.