### PR TITLE
Remove default values in kubernetes descriptors

### DIFF
--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -24,85 +24,63 @@ spec:
             - name: ACPROXY_LOGGING_LEVEL
               value: debug
           image: aiarena/arenaclient-proxy:latest
-          imagePullPolicy: Always
           name: proxy-controller
           ports:
             - containerPort: 8080
               name: 8080tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8080
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           volumeMounts:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
           __active: true
-          resources: {}
         - env:
             - name: ACBOT_PORT
               value: '8081'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-1
           ports:
             - containerPort: 8081
               name: 8081tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8081
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACBOT_PORT
               value: '8082'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-2
           ports:
             - containerPort: 8082
               name: 8082tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8082
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACSC2_PORT
               value: '8083'
@@ -111,36 +89,21 @@ spec:
             - name: SC2PATH
               value: /root/StarCraftII
           image: aiarena/arenaclient-sc2:latest
-          imagePullPolicy: Always
           name: sc2-controller
           ports:
             - containerPort: 8083
               name: 8083tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8083
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          resources: {}
-      dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      nodeSelector:
-        {}
       restartPolicy: Never
-      schedulerName: default-scheduler
-      terminationGracePeriodSeconds: 30
       volumes:
-        - configMap:
+        - name: config
+          configMap:
             defaultMode: 420
             name: placeholder
-            optional: false
-          name: config
   backoffLimit: 6
 __clone: true

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -2,10 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: k8s-controller-config
-  annotations:
-    {}
-  labels:
-    {}
   namespace: arenaclients
 data:
   config.toml: |-

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,51 +1,32 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: arenaclients
+  name: k8s-controller
   labels:
     app: aiarena-k8s-controller
-  name: k8s-controller
-  namespace: arenaclients
 spec:
-  progressDeadlineSeconds: 600
   replicas: 1
-  revisionHistoryLimit: 5
   selector:	
     matchLabels:	
       app: aiarena-k8s-controller
-  strategy:
-    rollingUpdate:
-      maxSurge: 25%
-      maxUnavailable: 25%
-    type: RollingUpdate
   template:
     metadata:
-      annotations:
-        cattle.io/timestamp: "2023-01-21T11:43:14Z"
-      creationTimestamp: null
       labels:	
         app: aiarena-k8s-controller
     spec:
-      affinity: {}
       containers:
       - image: aiarena/k8s-controller
-        imagePullPolicy: Always
         name: k8s-controller
         ports:
         - containerPort: 8085
           name: 8085tcp
           protocol: TCP
         readinessProbe:
-          failureThreshold: 3
           httpGet:
             path: /health
             port: 8085
             scheme: HTTP
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
         volumeMounts:
         - mountPath: /app/arenaclients.json
           name: arenaclients-json
@@ -53,21 +34,15 @@ spec:
         - mountPath: /app/config.toml
           name: config
           subPath: config.toml
-      dnsPolicy: ClusterFirst
       restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
       serviceAccount: k8s-controller
       serviceAccountName: k8s-controller
-      terminationGracePeriodSeconds: 30
       volumes:
       - name: arenaclients-json
         secret:
           defaultMode: 420
-          optional: false
           secretName: arenaclients-secrets
-      - configMap:
+      - name: config
+        configMap:
           defaultMode: 420
           name: k8s-controller-config
-          optional: false
-        name: config


### PR DESCRIPTION
All removed lines are defaults in these Kubernetes descriptors with the only exception of the imagePullPolicy. The default for "latest" tag Docker images is "Always" but for version tag images it's "IfNotPresent" which performs better when the release process always increments the version. So removing the line and using the default improves it.
We're not interested in setting specific values for those properties so it's better to use the defaults.
