### PR TITLE
Add sc2_controller.log to ac_log.zip

### DIFF
--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -39,6 +39,8 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
+            - mountPath: /logs
+              name: logs
           __active: true
         - env:
             - name: ACBOT_PORT
@@ -100,11 +102,16 @@ spec:
               path: /health
               port: 8083
               scheme: HTTP
+          volumeMounts:
+            - mountPath: /logs
+              name: logs
       restartPolicy: Never
       volumes:
         - name: config
           configMap:
             defaultMode: 420
             name: placeholder
+        - name: logs
+          emptyDir: {}
   backoffLimit: 6
 __clone: true

--- a/proxy_controller/src/match_scheduler/mod.rs
+++ b/proxy_controller/src/match_scheduler/mod.rs
@@ -323,10 +323,7 @@ async fn build_logs_and_replays_object(
         .unwrap(); // todo: dont unwrap
 
     // Copy sc2_controller logs
-    let sc2_log_path_str = format!(
-        "{}/sc2_controller/sc2_controller.log",
-        &settings.log_root
-    );
+    let sc2_log_path_str = format!("{}/sc2_controller/sc2_controller.log", &settings.log_root);
     let sc2_log_path = Path::new(&sc2_log_path_str).to_path_buf();
 
     if sc2_log_path.exists() {

--- a/proxy_controller/src/match_scheduler/mod.rs
+++ b/proxy_controller/src/match_scheduler/mod.rs
@@ -322,6 +322,21 @@ async fn build_logs_and_replays_object(
         .await
         .unwrap(); // todo: dont unwrap
 
+    // Copy sc2_controller logs
+    let sc2_log_path_str = format!(
+        "{}/sc2_controller/sc2_controller.log",
+        &settings.log_root
+    );
+    let sc2_log_path = Path::new(&sc2_log_path_str).to_path_buf();
+
+    if sc2_log_path.exists() {
+        let _ = tokio::fs::copy(
+            sc2_log_path,
+            arenaclient_log_directory.join("sc2_controller.log"),
+        )
+        .await;
+    }
+
     // Copy proxy_controller logs last to pick up any potential issues
     let proxy_log_path_str = format!(
         "{}/proxy_controller/proxy_controller.log",
@@ -336,6 +351,8 @@ async fn build_logs_and_replays_object(
         )
         .await;
     }
+
+    // Zip all log files into a single zip file
     let arenaclient_logs_zip_path = temp_folder.join("ac_log.zip");
 
     let ac_zip_result = common::utilities::zip_utils::zip_directory_to_path(


### PR DESCRIPTION
The change includes SC2 logs in AC logs upload (as requested in https://github.com/aiarena/sc2-ai-match-controller/issues/56) but it doesn't use the HTTP endpoint of sc2_controller as it's done when including bot logs. That's why I activate the change on in the strict mode. If this works as expected, I'll prepare a new pull request to activate it for all matches but also refactor the way bot logs are included in the AC logs zip to use the shared logs folder rather than download them via the HTTP endpoint of bot_controller.