### PR TITLE
Update ac-job.yaml to the strict version

### DIFF
--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -7,6 +7,11 @@ spec:
   template:
     spec:
       activeDeadlineSeconds: 9000
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
       containers:
         - env:
             - name: ACPROXY_PORT
@@ -20,121 +25,93 @@ spec:
             - name: ACPROXY_LOGGING_LEVEL
               value: debug
           image: aiarena/arenaclient-proxy:latest
-          imagePullPolicy: Always
           name: proxy-controller
           ports:
             - containerPort: 8080
               name: 8080tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8080
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           volumeMounts:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
+            - mountPath: /logs
+              name: logs
           __active: true
-          resources: {}
         - env:
             - name: ACBOT_PORT
               value: '8081'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-1
           ports:
             - containerPort: 8081
               name: 8081tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8081
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACBOT_PORT
               value: '8082'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-2
           ports:
             - containerPort: 8082
               name: 8082tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8082
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACSC2_PORT
               value: '8083'
             - name: ACSC2_PROXY_HOST
               value: 127.0.0.1
+            - name: SC2PATH
+              value: /root/StarCraftII
           image: aiarena/arenaclient-sc2:latest
-          imagePullPolicy: Always
           name: sc2-controller
           ports:
             - containerPort: 8083
               name: 8083tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8083
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          resources: {}
-      dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      nodeSelector:
-        {}
+          volumeMounts:
+            - mountPath: /logs
+              name: logs
       restartPolicy: Never
-      schedulerName: default-scheduler
-      terminationGracePeriodSeconds: 30
       volumes:
-        - configMap:
+        - name: config
+          configMap:
             defaultMode: 420
             name: placeholder
-            optional: false
-          name: config
+        - name: logs
+          emptyDir: {}
   backoffLimit: 6
 __clone: true


### PR DESCRIPTION
Tested with https://aiarena.net/matches/3664642/ (normal bots get a normal match result) and https://aiarena.net/matches/3664563/ (Elo Vampire logs the effects of changes):
* Bots don't have Kubernetes API access token
* Bots run with non-root user 65532
* Docker images are not pulled from repository if they have previously been downloaded
* Default values of Kubernetes descriptor removed for clarity
* sc2-controller and proxy-controller share a folder to deliver log files (See presence of sc2_controller.log in AC log zips of both matches)