### PR TITLE
Download controller logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
@@ -107,6 +114,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
+
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
@@ -118,6 +132,13 @@ jobs:
     name: API-based integration test
     runs-on: ubuntu-latest
     steps:
+
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          large-packages: false
+          tool-cache: false
+          swap-storage: false
 
       - uses: actions/checkout@v4
 

--- a/bot_controller/src/main.rs
+++ b/bot_controller/src/main.rs
@@ -6,7 +6,7 @@ mod utils;
 #[cfg(feature = "swagger")]
 use crate::docs::ApiDoc;
 use crate::routes::{
-    download_bot_data, download_bot_log, download_controller_log, start_bot, terminate_bot,
+    download_bot_data, download_bot_log, start_bot, terminate_bot,
 };
 use axum::http::Request;
 use axum::response::Response;
@@ -95,7 +95,6 @@ async fn main() {
         .route("/terminate_all", post(terminate_all))
         .route("/terminate/:bot_name", post(terminate_bot))
         .route("/shutdown", post(shutdown))
-        .route("/download/controller_log", get(download_controller_log))
         .route("/download/bot/:port/log", get(download_bot_log))
         .route("/download/bot/:port/data", get(download_bot_data))
         // Add middleware to all routes

--- a/bot_controller/src/main.rs
+++ b/bot_controller/src/main.rs
@@ -5,9 +5,7 @@ mod utils;
 
 #[cfg(feature = "swagger")]
 use crate::docs::ApiDoc;
-use crate::routes::{
-    download_bot_data, download_bot_log, start_bot, terminate_bot,
-};
+use crate::routes::{download_bot_data, download_bot_log, start_bot, terminate_bot};
 use axum::http::Request;
 use axum::response::Response;
 use axum::routing::{get, post};

--- a/bot_controller/src/routes.rs
+++ b/bot_controller/src/routes.rs
@@ -312,33 +312,6 @@ pub async fn start_bot(
 #[tracing::instrument(skip(state))]
 #[cfg_attr(feature = "swagger", utoipa::path(
 get,
-path = "/download/controller_log",
-responses(
-(status = 200, description = "Request Completed")
-)
-))]
-pub async fn download_controller_log(
-    State(state): State<AppState>,
-) -> Result<FileResponse, AppError> {
-    let log_path = format!(
-        "{}/bot_controller/bot_controller.log",
-        &state.settings.log_root
-    );
-    let file = tokio::fs::File::open(&log_path)
-        .await
-        .map_err(|e| AppError::Download(DownloadError::FileNotFound(e)))?;
-    // convert the `AsyncRead` into a `Stream`
-    let stream = ReaderStream::new(file);
-    // convert the `Stream` into an `axum::body::HttpBody`
-    let body = StreamBody::new(stream);
-
-    let headers = [(header::CONTENT_TYPE, "text/log; charset=utf-8")];
-    Ok((headers, body))
-}
-
-#[tracing::instrument(skip(state))]
-#[cfg_attr(feature = "swagger", utoipa::path(
-get,
 path = "/download/bot/{process_key}/log",
 params(
 ("process_key" = u16, Path, description = "process_key of bot process to fetch logs for")

--- a/common/src/api/api_reference/mod.rs
+++ b/common/src/api/api_reference/mod.rs
@@ -272,15 +272,6 @@ pub trait ControllerApi {
             }
         }
     }
-    async fn download_controller_log(&self) -> Result<Bytes, ApiError<ApiErrorMessage>> {
-        let log_url = self.url().join("/download/controller_log").unwrap(); // static string, so the constructor should catch any parse
-                                                                            // errors
-        let request = self
-            .client()
-            .request(reqwest::Method::GET, log_url)
-            .build()?;
-        self.execute_request_file(request).await
-    }
 }
 
 #[derive(Debug)]

--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
-            - mountPath: /logs/proxy_controller
+            - mountPath: /logs
               name: logs
               subPath: proxy-controller
           __active: true

--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -41,7 +41,6 @@ spec:
               subPath: config.toml
             - mountPath: /logs
               name: logs
-              subPath: proxy-controller
           __active: true
         - env:
             - name: ACBOT_PORT

--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -39,8 +39,9 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
-            - mountPath: /logs
+            - mountPath: /logs/proxy_controller
               name: logs
+              subPath: proxy-controller
           __active: true
         - env:
             - name: ACBOT_PORT
@@ -63,6 +64,10 @@ spec:
               cpu: '2'
             requests:
               cpu: '1'
+          volumeMounts:
+            - mountPath: /logs/bot_controller
+              name: logs
+              subPath: bot-controller-1
         - env:
             - name: ACBOT_PORT
               value: '8082'
@@ -84,6 +89,10 @@ spec:
               cpu: '2'
             requests:
               cpu: '1'
+          volumeMounts:
+            - mountPath: /logs/bot_controller
+              name: logs
+              subPath: bot-controller-2
         - env:
             - name: ACSC2_PORT
               value: '8083'
@@ -103,8 +112,9 @@ spec:
               port: 8083
               scheme: HTTP
           volumeMounts:
-            - mountPath: /logs
+            - mountPath: /logs/sc2_controller
               name: logs
+              subPath: sc2-controller
       restartPolicy: Never
       volumes:
         - name: config

--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -39,6 +39,8 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
+            - mountPath: /logs
+              name: logs
           __active: true
         - env:
             - name: ACBOT_PORT
@@ -100,11 +102,16 @@ spec:
               path: /health
               port: 8083
               scheme: HTTP
+          volumeMounts:
+            - mountPath: /logs
+              name: logs
       restartPolicy: Never
       volumes:
         - name: config
           configMap:
             defaultMode: 420
             name: placeholder
+        - name: logs
+          emptyDir: {}
   backoffLimit: 6
 __clone: true

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -7,6 +7,11 @@ spec:
   template:
     spec:
       activeDeadlineSeconds: 9000
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
       containers:
         - env:
             - name: ACPROXY_PORT
@@ -20,121 +25,93 @@ spec:
             - name: ACPROXY_LOGGING_LEVEL
               value: debug
           image: aiarena/arenaclient-proxy:latest
-          imagePullPolicy: Always
           name: proxy-controller
           ports:
             - containerPort: 8080
               name: 8080tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8080
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
           volumeMounts:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
+            - mountPath: /logs
+              name: logs
           __active: true
-          resources: {}
         - env:
             - name: ACBOT_PORT
               value: '8081'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-1
           ports:
             - containerPort: 8081
               name: 8081tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8081
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACBOT_PORT
               value: '8082'
             - name: ACBOT_PROXY_HOST
               value: 127.0.0.1
           image: aiarena/arenaclient-bot:latest
-          imagePullPolicy: Always
           name: bot-controller-2
           ports:
             - containerPort: 8082
               name: 8082tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8082
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
           resources:
             limits:
               cpu: '2'
             requests:
               cpu: '1'
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
         - env:
             - name: ACSC2_PORT
               value: '8083'
             - name: ACSC2_PROXY_HOST
               value: 127.0.0.1
+            - name: SC2PATH
+              value: /root/StarCraftII
           image: aiarena/arenaclient-sc2:latest
-          imagePullPolicy: Always
           name: sc2-controller
           ports:
             - containerPort: 8083
               name: 8083tcp
               protocol: TCP
           readinessProbe:
-            failureThreshold: 3
             httpGet:
               path: /health
               port: 8083
               scheme: HTTP
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
-          resources: {}
-      dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      nodeSelector:
-        {}
+          volumeMounts:
+            - mountPath: /logs
+              name: logs
       restartPolicy: Never
-      schedulerName: default-scheduler
-      terminationGracePeriodSeconds: 30
       volumes:
-        - configMap:
+        - name: config
+          configMap:
             defaultMode: 420
             name: placeholder
-            optional: false
-          name: config
+        - name: logs
+          emptyDir: {}
   backoffLimit: 6
 __clone: true

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
-            - mountPath: /logs/proxy_controller
+            - mountPath: /logs
               name: logs
               subPath: proxy-controller
           __active: true

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -41,7 +41,6 @@ spec:
               subPath: config.toml
             - mountPath: /logs
               name: logs
-              subPath: proxy-controller
           __active: true
         - env:
             - name: ACBOT_PORT

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -39,8 +39,9 @@ spec:
             - mountPath: /app/config.toml
               name: config
               subPath: config.toml
-            - mountPath: /logs
+            - mountPath: /logs/proxy_controller
               name: logs
+              subPath: proxy-controller
           __active: true
         - env:
             - name: ACBOT_PORT
@@ -63,6 +64,10 @@ spec:
               cpu: '2'
             requests:
               cpu: '1'
+          volumeMounts:
+            - mountPath: /logs/bot_controller
+              name: logs
+              subPath: bot-controller-1
         - env:
             - name: ACBOT_PORT
               value: '8082'
@@ -84,6 +89,10 @@ spec:
               cpu: '2'
             requests:
               cpu: '1'
+          volumeMounts:
+            - mountPath: /logs/bot_controller
+              name: logs
+              subPath: bot-controller-2
         - env:
             - name: ACSC2_PORT
               value: '8083'
@@ -103,8 +112,9 @@ spec:
               port: 8083
               scheme: HTTP
           volumeMounts:
-            - mountPath: /logs
+            - mountPath: /logs/sc2_controller
               name: logs
+              subPath: sc2-controller
       restartPolicy: Never
       volumes:
         - name: config

--- a/proxy_controller/src/match_scheduler/mod.rs
+++ b/proxy_controller/src/match_scheduler/mod.rs
@@ -319,11 +319,12 @@ async fn build_logs_and_replays_object(
     let (bot1_dir, bot2_dir) = build_bot_logs(&temp_folder, bot_controllers).await.unwrap();
 
     // Zip all log files into a single zip file
+    let log_root_path = Path::new(&settings.log_root);
     let arenaclient_logs_zip_path = temp_folder.join("ac_log.zip");
 
     let ac_zip_result = common::utilities::zip_utils::zip_directory_to_path(
         &arenaclient_logs_zip_path,
-        &settings.log_root,
+        &log_root_path,
     );
 
     match ac_zip_result {

--- a/proxy_controller/src/match_scheduler/mod.rs
+++ b/proxy_controller/src/match_scheduler/mod.rs
@@ -318,43 +318,12 @@ async fn build_logs_and_replays_object(
 
     let (bot1_dir, bot2_dir) = build_bot_logs(&temp_folder, bot_controllers).await.unwrap();
 
-    let arenaclient_log_directory = build_arenaclient_logs(&temp_folder, bot_controllers)
-        .await
-        .unwrap(); // todo: dont unwrap
-
-    // Copy sc2_controller logs
-    let sc2_log_path_str = format!("{}/sc2_controller/sc2_controller.log", &settings.log_root);
-    let sc2_log_path = Path::new(&sc2_log_path_str).to_path_buf();
-
-    if sc2_log_path.exists() {
-        let _ = tokio::fs::copy(
-            sc2_log_path,
-            arenaclient_log_directory.join("sc2_controller.log"),
-        )
-        .await;
-    }
-
-    // Copy proxy_controller logs last to pick up any potential issues
-    let proxy_log_path_str = format!(
-        "{}/proxy_controller/proxy_controller.log",
-        &settings.log_root
-    );
-    let proxy_log_path = Path::new(&proxy_log_path_str).to_path_buf();
-
-    if proxy_log_path.exists() {
-        let _ = tokio::fs::copy(
-            proxy_log_path,
-            arenaclient_log_directory.join("proxy_controller.log"),
-        )
-        .await;
-    }
-
     // Zip all log files into a single zip file
     let arenaclient_logs_zip_path = temp_folder.join("ac_log.zip");
 
     let ac_zip_result = common::utilities::zip_utils::zip_directory_to_path(
         &arenaclient_logs_zip_path,
-        &arenaclient_log_directory,
+        &settings.log_root,
     );
 
     match ac_zip_result {
@@ -466,34 +435,6 @@ fn clean_up_state(state: &mut ProxyState) {
 async fn write_file(path: &Path, bytes: &Bytes) -> std::io::Result<()> {
     let mut file = File::create(path).await?;
     file.write_all(bytes.as_ref()).await
-}
-
-async fn build_arenaclient_logs(
-    temp_folder: &Path,
-    bot_controllers: &[BotController],
-) -> io::Result<PathBuf> {
-    let arenaclient_logs_dir = temp_folder.join("arenaclient");
-    tokio::fs::create_dir(&arenaclient_logs_dir).await?;
-
-    let bot_controller_dir = arenaclient_logs_dir.join("bot");
-    tokio::fs::create_dir(&bot_controller_dir).await?;
-
-    let res = join(
-        bot_controllers[0].download_controller_log().and_then(|x| {
-            let file_path = bot_controller_dir.join("bot_controller1.log");
-            async move { write_file(&file_path, &x).await.map_err(ApiError::from) }
-        }),
-        bot_controllers[1].download_controller_log().and_then(|x| {
-            let file_path = bot_controller_dir.join("bot_controller2.log");
-            async move { write_file(&file_path, &x).await.map_err(ApiError::from) }
-        }),
-    )
-    .await;
-    if let (Err(e), _) | (_, Err(e)) = res {
-        error!("{:?}", e)
-    }
-
-    Ok(arenaclient_logs_dir)
 }
 
 fn create_start_bot(

--- a/proxy_controller/src/match_scheduler/mod.rs
+++ b/proxy_controller/src/match_scheduler/mod.rs
@@ -322,6 +322,18 @@ async fn build_logs_and_replays_object(
         .await
         .unwrap(); // todo: dont unwrap
 
+    // Copy sc2_controller logs
+    let sc2_log_path_str = format!("{}/sc2_controller/sc2_controller.log", &settings.log_root);
+    let sc2_log_path = Path::new(&sc2_log_path_str).to_path_buf();
+
+    if sc2_log_path.exists() {
+        let _ = tokio::fs::copy(
+            sc2_log_path,
+            arenaclient_log_directory.join("sc2_controller.log"),
+        )
+        .await;
+    }
+
     // Copy proxy_controller logs last to pick up any potential issues
     let proxy_log_path_str = format!(
         "{}/proxy_controller/proxy_controller.log",
@@ -336,6 +348,8 @@ async fn build_logs_and_replays_object(
         )
         .await;
     }
+
+    // Zip all log files into a single zip file
     let arenaclient_logs_zip_path = temp_folder.join("ac_log.zip");
 
     let ac_zip_result = common::utilities::zip_utils::zip_directory_to_path(

--- a/sc2_controller/src/main.rs
+++ b/sc2_controller/src/main.rs
@@ -4,7 +4,7 @@ mod routes;
 
 #[cfg(feature = "swagger")]
 use crate::docs::ApiDoc;
-use crate::routes::{download_controller_log, find_map, start_sc2, terminate_sc2};
+use crate::routes::{find_map, start_sc2, terminate_sc2};
 use axum::http::Request;
 use axum::response::Response;
 use axum::routing::{get, post};
@@ -89,7 +89,6 @@ async fn main() {
         .route("/terminate_all", post(terminate_all))
         .route("/shutdown", post(shutdown))
         .route("/find_map/:map_name", get(find_map))
-        .route("/download/controller_log", get(download_controller_log))
         .layer(
             TraceLayer::new_for_http()
                 .on_request(|request: &Request<_>, _span: &Span| {

--- a/sc2_controller/src/routes.rs
+++ b/sc2_controller/src/routes.rs
@@ -1,9 +1,6 @@
-use axum::body::StreamBody;
 use axum::extract::{Path, State};
-use axum::http::header;
 use axum::Json;
 use common::api::errors::app_error::AppError;
-use common::api::errors::download_error::DownloadError;
 use common::api::errors::map_error::MapError;
 use common::api::errors::process_error::ProcessError;
 use common::api::state::AppState;
@@ -14,11 +11,9 @@ use common::paths;
 use common::portpicker::pick_unused_port_in_range;
 use common::utilities::directory::ensure_directory_structure;
 use common::utilities::portpicker::Port;
-use reqwest::header::HeaderName;
 use reqwest::Client;
 use tempfile::TempDir;
 use tokio::io::AsyncWriteExt;
-use tokio_util::io::ReaderStream;
 use tracing::info;
 
 use crate::PREFIX;

--- a/sc2_controller/src/routes.rs
+++ b/sc2_controller/src/routes.rs
@@ -107,31 +107,6 @@ pub async fn start_sc2(State(state): State<AppState>) -> Result<Json<StartRespon
     }
 }
 
-pub async fn download_controller_log(
-    State(state): State<AppState>,
-) -> Result<
-    (
-        [(HeaderName, &'static str); 1],
-        StreamBody<ReaderStream<tokio::fs::File>>,
-    ),
-    AppError,
-> {
-    let log_path = format!(
-        "{}/sc2_controller/sc2_controller.log",
-        &state.settings.log_root
-    );
-    let file = tokio::fs::File::open(&log_path)
-        .await
-        .map_err(|e| AppError::Download(DownloadError::FileNotFound(e)))?;
-    // convert the `AsyncRead` into a `Stream`
-    let stream = ReaderStream::new(file);
-    // convert the `Stream` into an `axum::body::HttpBody`
-    let body = StreamBody::new(stream);
-
-    let headers = [(header::CONTENT_TYPE, "text/log; charset=utf-8")];
-    Ok((headers, body))
-}
-
 #[tracing::instrument]
 #[cfg_attr(feature = "swagger",utoipa::path(
 get,


### PR DESCRIPTION
All controller logs are in one volume. The proxy controller doesn't have to use HTTP calls to collect them. It just zips the shared folder.