### PR TITLE
Fix logs mount in Kubernetes

### DIFF
--- a/k8s_controller/templates/ac-job-strict.yaml
+++ b/k8s_controller/templates/ac-job-strict.yaml
@@ -101,7 +101,7 @@ spec:
           volumeMounts:
             - mountPath: /logs/sc2_controller
               name: logs
-              subPath: sc2-controller
+              subPath: sc2_controller
             - mountPath: /root/StarCraftII/maps
               name: game
       containers:

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -101,7 +101,7 @@ spec:
           volumeMounts:
             - mountPath: /logs/sc2_controller
               name: logs
-              subPath: sc2-controller
+              subPath: sc2_controller
             - mountPath: /root/StarCraftII/maps
               name: game
       containers:


### PR DESCRIPTION
A tiny fix in how /logs/sc2_controller is mounted in Kubernetes to match the way it's used from the Rust code.