### PR TITLE
Restore SC2 max game time to 1 hour

### DIFF
--- a/match_controller/config.toml
+++ b/match_controller/config.toml
@@ -16,7 +16,7 @@ BOT_DIRECTORY = "/bots"
 GAME_DIRECTORY = "/game"
 
 # STARCRAFT
-MAX_GAME_TIME = 60486
+MAX_GAME_TIME = 80640 # 1 hour in fast speed in-game time
 MAX_REAL_TIME = 7200  # 2 hours in seconds
 MAX_FRAME_TIME = 40 # milliseconds
 REALTIME = false

--- a/sc2_controller/README.md
+++ b/sc2_controller/README.md
@@ -9,7 +9,7 @@ The controller reads the following parameters from `/match/match-request.toml` a
 |-----|---------|-------------|
 | map_name | - | The name of the StarCraft II map for the match. |
 | match_id | - | An identifier for the match as seen in AI Arena |
-| max_game_time | 60486 | Maximum game loops for the match. After this limit, the controller will close the match and call it a tie. |
+| max_game_time | 80640 | Maximum game loops for the match. After this limit, the controller will close the match and call it a tie. |
 | max_frame_time | 40 | Milliseconds waiting for a bot to process a game step. After this limit the controller will raise a timeout for this bot. |
 | player_1_id | - | Identifier of player 1 |
 | player_1_name | - | Display name of player 1 |

--- a/sc2_controller/src/game/game_config.rs
+++ b/sc2_controller/src/game/game_config.rs
@@ -58,7 +58,7 @@ impl GameConfig {
             map: map_name.to_string(),
             players: players,
 
-            max_game_time: 60486,
+            max_game_time: 80640,
             max_frame_time: 40,
             timeout_secs: 30,
             replay_path: "/root/StarCraftII/maps".to_string(),


### PR DESCRIPTION
Restoring the maximum game time for StarCraft 2. I have mistakenly reduced it to 45 minutes when consolidating the various configuration files.