### PR TITLE
Improved CPU utilization in Kubernetes

### DIFF
--- a/k8s_controller/src/k8s_processor.rs
+++ b/k8s_controller/src/k8s_processor.rs
@@ -139,7 +139,15 @@ async fn schedule_jobs(
                     new_match.id, &ac.name
                 );
                 debug!("Creating job");
-                jobs.create(&PostParams::default(), &job_data).await?;
+                if let Err(e) = jobs.create(&PostParams::default(), &job_data).await {
+                    error!(
+                        "Error creating job {:?} for AC {:?}: {:?}",
+                        job_name, &ac.name, e
+                    );
+                    // Error when creating the job for one arenaclient should not break the loop
+                    // Otherwise, a temporary glitch for client 1 blocks all other clients
+                    continue;
+                }
                 debug!("Job created");
             }
             Err(e) => {

--- a/k8s_controller/templates/ac-job.yaml
+++ b/k8s_controller/templates/ac-job.yaml
@@ -63,6 +63,17 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 10002
+          # Game and bot controllers are limited to 2 cpu units
+          # and made burstable with lower cpu requests.
+          # We use same cpu requests for both game and bot controllers
+          # because Kubernetes uses cpu requests as basis for cpu sharing
+          # Total requested cpu for the job pod is 1.5 (3 x 0.5)
+          # Actual utilization averages between 1.2 and 1.6
+          resources:
+            limits:
+              cpu: '2'
+            requests:
+              cpu: '0.5'
           volumeMounts:
             - mountPath: /root/StarCraftII/maps
               name: game
@@ -89,7 +100,7 @@ spec:
             limits:
               cpu: '2'
             requests:
-              cpu: '1'
+              cpu: '0.5'
           volumeMounts:
             - mountPath: /bot
               name: bots
@@ -115,7 +126,7 @@ spec:
             limits:
               cpu: '2'
             requests:
-              cpu: '1'
+              cpu: '0.5'
           volumeMounts:
             - mountPath: /bot
               name: bots


### PR DESCRIPTION
Three improvements in cpu utilization that I used at the end of [Sc2 AI Arena 2026 Pre-Season 1](https://aiarena.net/competitions/35) to help the ladder with unblocking from the multiple initialization errors:
* All cpu-intensive containers in the Kubernetes job (the game and bot controllers) have the same cpu requests so they get the same prioritization in cpu sharing
* The sum of cpu requests for the Kubernetes job allows for all 12 arenaclients to get started on the current setup. Previously the requests blocked the last client due to insufficient cpu, although cpu utilization was well below 80%
* Temporary issues with one client - such as 502 Bad Gateway HTTP response or a cancelled match - don't block the other clients from running matches