### PR TITLE
Use GraphQL to submit match results

### DIFF
--- a/k8s_controller/Cargo.toml
+++ b/k8s_controller/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 anyhow = "^1.0.68"
 axum = { version = "0.6.2" }
+base64 = "0.22"
 chrono = "0.4"
 common = { path="../common" }
 config = { git = "https://github.com/mehcode/config-rs.git", default-features=false, features=["toml"] }
@@ -15,6 +16,7 @@ futures-util = "0.3.25"
 k8s-openapi = { version = "0.25.0", default-features = false, features = ["v1_30"] }
 kube = {  version = "1.1.0", default-features = false, features = ["client", "runtime", "rustls-tls"] }
 parking_lot = {version = "0.12.1" }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 rustls = { version = "0.23.31", features = ["ring"] }
 serde = {  version = "^1.0" }
 serde_json = "1.0.87"

--- a/k8s_controller/src/arena_api.rs
+++ b/k8s_controller/src/arena_api.rs
@@ -1,0 +1,135 @@
+use anyhow::{anyhow, Context};
+use base64::{engine::general_purpose::STANDARD, Engine};
+use common::models::aiarena::aiarena_bot::AiArenaBot;
+use common::models::aiarena::aiarena_map::AiArenaMap;
+use common::models::aiarena::aiarena_match::AiArenaMatch;
+use reqwest::Client;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+struct GraphQLResponse {
+    data: Option<GetNextMatchData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetNextMatchData {
+    get_next_match: Option<GetNextMatch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetNextMatch {
+    #[serde(rename = "match")]
+    match_info: Option<MatchInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct MatchInfo {
+    id: String,
+    participant1: Participant,
+    participant2: Participant,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Participant {
+    name: String,
+    game_display_id: String,
+}
+
+const GET_NEXT_MATCH_QUERY: &str = r#"
+mutation {
+  getNextMatch {
+    match {
+      id
+      participant1 {
+        name
+        gameDisplayId
+      }
+      participant2 {
+        name
+        gameDisplayId
+      }
+    }
+  }
+}
+"#;
+
+pub async fn get_next_match(website_url: &str, token: &str) -> anyhow::Result<AiArenaMatch> {
+    let client = Client::new();
+
+    let body = serde_json::json!({
+        "query": GET_NEXT_MATCH_QUERY,
+    });
+
+    let url = format!("{}/graphql/", website_url.trim_end_matches('/'));
+
+    let resp = client
+        .post(&url)
+        .header("Authorization", format!("Token {}", token))
+        .header("Accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("Failed to send GraphQL request")?;
+
+    let text = resp.text().await.context("Failed to read response body")?;
+
+    let parsed: GraphQLResponse =
+        serde_json::from_str(&text).context("Failed to parse GraphQL response")?;
+
+    let match_info = parsed
+        .data
+        .ok_or_else(|| anyhow!("GraphQL response has no data"))?
+        .get_next_match
+        .ok_or_else(|| anyhow!("GraphQL response has no getNextMatch"))?
+        .match_info
+        .ok_or_else(|| anyhow!("GraphQL response has no match"))?;
+
+    Ok(convert_to_aiarena_match(match_info))
+}
+
+fn convert_to_aiarena_match(m: MatchInfo) -> AiArenaMatch {
+    let id = decode_base64_id(&m.id).unwrap_or(0);
+    AiArenaMatch {
+        id,
+        bot1: AiArenaBot {
+            id: 0,
+            name: m.participant1.name,
+            game_display_id: m.participant1.game_display_id,
+            bot_zip: String::new(),
+            bot_zip_md5hash: String::new(),
+            bot_data: None,
+            bot_data_md5hash: None,
+            plays_race: String::new(),
+            _type: String::new(),
+            bot_base: None,
+        },
+        bot2: AiArenaBot {
+            id: 0,
+            name: m.participant2.name,
+            game_display_id: m.participant2.game_display_id,
+            bot_zip: String::new(),
+            bot_zip_md5hash: String::new(),
+            bot_data: None,
+            bot_data_md5hash: None,
+            plays_race: String::new(),
+            _type: String::new(),
+            bot_base: None,
+        },
+        map: AiArenaMap {
+            name: String::new(),
+            file: String::new(),
+            file_hash: None,
+        },
+        game_base: None,
+    }
+}
+
+fn decode_base64_id(encoded: &str) -> Option<u32> {
+    let bytes = STANDARD.decode(encoded).ok()?;
+    let decoded = String::from_utf8(bytes).ok()?;
+    let id_str = decoded.rsplit(':').next()?;
+    id_str.parse().ok()
+}

--- a/k8s_controller/src/k8s_processor.rs
+++ b/k8s_controller/src/k8s_processor.rs
@@ -1,6 +1,5 @@
 use crate::templating::{render_job_template, JobTemplateValues};
-use crate::{arenaclient::Arenaclient, k8s_config::K8sConfig, profile::Profile};
-use common::api::api_reference::aiarena::aiarena_api_client::AiArenaApiClient;
+use crate::{arena_api, arenaclient::Arenaclient, k8s_config::K8sConfig, profile::Profile};
 use k8s_openapi::api::batch::v1::Job;
 use kube::{
     api::{Api, ListParams, PostParams},
@@ -79,8 +78,7 @@ pub async fn process(settings: K8sConfig) {
 }
 
 async fn retrieve_match(settings: &K8sConfig, ac: &Arenaclient) -> anyhow::Result<Job> {
-    let api_client = AiArenaApiClient::new(&settings.website_url, &ac.token)?;
-    let new_match = api_client.get_match().await?;
+    let new_match = arena_api::get_next_match(&settings.website_url, &ac.token).await?;
 
     info!("Retrieved match {:?} for AC {:?}", new_match.id, ac.name);
 

--- a/k8s_controller/src/main.rs
+++ b/k8s_controller/src/main.rs
@@ -1,3 +1,4 @@
+mod arena_api;
 mod arenaclient;
 // mod old;
 mod k8s_config;

--- a/match_controller/Cargo.toml
+++ b/match_controller/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "^1.0.68"
 async-trait = "0.1.58"
 axum = { version = "0.6.2", features = ["ws"] }
+base64 = "0.22"
 bytes = "1.3.0"
 common = { path="../common" }
 config = { git = "https://github.com/mehcode/config-rs.git" , default-features=false, features=["toml"]}
@@ -15,6 +17,7 @@ clap = {version="4.3.0", features = ["cargo"]}
 futures-util = "0.3.25"
 indexmap = { version = "2.1.0", features = ["serde"] }
 parking_lot = { version = "0.12.1" }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.87"
 tokio = { version = "1.0", features = ["time", "macros", "rt-multi-thread", "signal"] }

--- a/match_controller/src/matches/sources/aiarena_api/graphql.rs
+++ b/match_controller/src/matches/sources/aiarena_api/graphql.rs
@@ -1,0 +1,324 @@
+use anyhow::{anyhow, Context};
+use base64::Engine;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tokio::time::Duration;
+use tracing::{error, info};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitResultInput {
+    #[serde(rename = "match")]
+    pub match_id: String,
+    #[serde(rename = "type")]
+    pub result_type: String,
+    pub game_steps: u32,
+    pub bot1_avg_step_time: f32,
+    pub bot2_avg_step_time: f32,
+    pub bot1_tags: Vec<String>,
+    pub bot2_tags: Vec<String>,
+    pub replay_file: String,
+    pub arenaclient_log: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub bot1_data: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub bot2_data: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub bot1_log: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub bot2_log: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadUrlsResponse {
+    data: Option<RequestUploadUrlsData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RequestUploadUrlsData {
+    request_upload_urls: Option<RequestUploadUrls>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RequestUploadUrls {
+    uploads: Vec<UploadEntry>,
+    errors: Vec<GraphQLFieldError>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadEntry {
+    upload: UploadInfo,
+    upload_url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct UploadInfo {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphQLFieldError {
+    field: String,
+    messages: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubmitResultResponse {
+    data: Option<SubmitResultData>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SubmitResultData {
+    submit_result: Option<SubmitResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubmitResult {
+    result: Option<ResultInfo>,
+    errors: Vec<GraphQLFieldError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResultInfo {
+    id: String,
+}
+
+const REQUEST_UPLOAD_URLS_QUERY: &str = r#"
+mutation($input: RequestUploadUrlsInput!) {
+  requestUploadUrls(input: $input) {
+    uploads {
+      upload {
+        id
+      }
+      uploadUrl
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}
+"#;
+
+const SUBMIT_RESULT_QUERY: &str = r#"
+mutation($input: SubmitResultInput!) {
+  submitResult(input: $input) {
+    result {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}
+"#;
+
+pub async fn upload_file_with_retries(
+    website_url: &str,
+    token: &str,
+    file_path: &Path,
+    retries: u32,
+) -> anyhow::Result<String> {
+    let limit = retries.max(1);
+    let mut last_err = None;
+
+    for attempt in 1..=limit {
+        match upload_file(website_url, token, file_path).await {
+            Ok(id) => return Ok(id),
+            Err(e) => {
+                error!(
+                    "Upload attempt {}/{} failed for {}: {}",
+                    attempt,
+                    limit,
+                    file_path.display(),
+                    e
+                );
+                last_err = Some(e);
+                if attempt < limit {
+                    // TODO: Implement incremental cooldown
+                    // 10s, 20s, 40s, 80s, 120s, 120s, until 10m.
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap())
+}
+
+async fn upload_file(
+    website_url: &str,
+    token: &str,
+    file_path: &Path,
+) -> anyhow::Result<String> {
+    let client = Client::new();
+    let graphql_url = format!("{}/graphql/", website_url.trim_end_matches('/'));
+
+    // Step 1: Request a signed upload URL
+    let body = serde_json::json!({
+        "query": REQUEST_UPLOAD_URLS_QUERY,
+        "variables": {
+            "input": {
+                "count": 1
+            }
+        }
+    });
+
+    let resp = client
+        .post(&graphql_url)
+        .header("Authorization", format!("Token {}", token))
+        .header("Accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("Failed to send requestUploadUrls GraphQL request")?;
+
+    let text = resp
+        .text()
+        .await
+        .context("Failed to read requestUploadUrls response body")?;
+
+    let parsed: UploadUrlsResponse =
+        serde_json::from_str(&text).context("Failed to parse requestUploadUrls response")?;
+
+    let upload_urls = parsed
+        .data
+        .ok_or_else(|| anyhow!("requestUploadUrls response has no data"))?
+        .request_upload_urls
+        .ok_or_else(|| anyhow!("requestUploadUrls response has no requestUploadUrls"))?;
+
+    if !upload_urls.errors.is_empty() {
+        let msgs: Vec<String> = upload_urls
+            .errors
+            .iter()
+            .map(|e| format!("{}: {}", e.field, e.messages.join(", ")))
+            .collect();
+        return Err(anyhow!("requestUploadUrls errors: {}", msgs.join("; ")));
+    }
+
+    let entry = upload_urls
+        .uploads
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow!("requestUploadUrls returned no uploads"))?;
+
+    let upload_id = entry.upload.id;
+    let upload_url = entry.upload_url;
+
+    // Step 2: Upload the file to the signed S3 URL
+    let file_bytes = tokio::fs::read(file_path)
+        .await
+        .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
+    let file_size_kb = file_bytes.len() / 1024;
+
+    info!("Uploading {} ({} KB) -> {}", file_path.display(), file_size_kb, upload_id);
+    client
+        .put(&upload_url)
+        .body(file_bytes)
+        .send()
+        .await
+        .context("Failed to upload file to S3")?
+        .error_for_status()
+        .context("S3 upload returned an error status")?;
+
+    // Step 3: Return the upload id
+    Ok(upload_id)
+}
+
+pub async fn submit_result_with_retries(
+    website_url: &str,
+    token: &str,
+    input: &SubmitResultInput,
+    retries: u32,
+) -> anyhow::Result<String> {
+    let limit = retries.max(1);
+    let mut last_err = None;
+
+    for attempt in 1..=limit {
+        match submit_result(website_url, token, input).await {
+            Ok(id) => return Ok(id),
+            Err(e) => {
+                error!(
+                    "Submit result attempt {}/{} failed: {}",
+                    attempt, limit, e
+                );
+                last_err = Some(e);
+                if attempt < limit {
+                    // TODO: Implement incremental cooldown
+                    // 10s, 20s, 40s, 80s, 120s, 120s, until 10m.
+                    tokio::time::sleep(Duration::from_secs(10)).await;
+                }
+            }
+        }
+    }
+    Err(last_err.unwrap())
+}
+
+async fn submit_result(
+    website_url: &str,
+    token: &str,
+    input: &SubmitResultInput,
+) -> anyhow::Result<String> {
+    let client = Client::new();
+    let graphql_url = format!("{}/graphql/", website_url.trim_end_matches('/'));
+
+    let body = serde_json::json!({
+        "query": SUBMIT_RESULT_QUERY,
+        "variables": {
+            "input": input
+        }
+    });
+
+    // TODO: Remove this trace before old API is retired
+    info!("Submitting result: {}", body);
+
+    let resp = client
+        .post(&graphql_url)
+        .header("Authorization", format!("Token {}", token))
+        .header("Accept", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .context("Failed to send submitResult GraphQL request")?;
+
+    let text = resp
+        .text()
+        .await
+        .context("Failed to read submitResult response body")?;
+
+    // TODO: Remove this trace before old API is retired
+    info!("Response to SubmitResult: |{}|", text);
+
+    let parsed: SubmitResultResponse =
+        serde_json::from_str(&text).context("Failed to parse submitResult response")?;
+
+    let submit_result = parsed
+        .data
+        .ok_or_else(|| anyhow!("submitResult response has no data"))?
+        .submit_result
+        .ok_or_else(|| anyhow!("submitResult response has no submitResult"))?;
+
+    if !submit_result.errors.is_empty() {
+        let msgs: Vec<String> = submit_result
+            .errors
+            .iter()
+            .map(|e| format!("{}: {}", e.field, e.messages.join(", ")))
+            .collect();
+        return Err(anyhow!("submitResult errors: {}", msgs.join("; ")));
+    }
+
+    let result_id = submit_result
+        .result
+        .ok_or_else(|| anyhow!("submitResult returned no result"))?
+        .id;
+
+    Ok(result_id)
+}
+
+pub fn encode_match_id(text: &str) -> String {
+    base64::engine::general_purpose::STANDARD.encode(format!("MatchType:{}", text))
+}

--- a/match_controller/src/matches/sources/aiarena_api/graphql.rs
+++ b/match_controller/src/matches/sources/aiarena_api/graphql.rs
@@ -150,11 +150,7 @@ pub async fn upload_file_with_retries(
     Err(last_err.unwrap())
 }
 
-async fn upload_file(
-    website_url: &str,
-    token: &str,
-    file_path: &Path,
-) -> anyhow::Result<String> {
+async fn upload_file(website_url: &str, token: &str, file_path: &Path) -> anyhow::Result<String> {
     let client = Client::new();
     let graphql_url = format!("{}/graphql/", website_url.trim_end_matches('/'));
 
@@ -215,7 +211,12 @@ async fn upload_file(
         .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
     let file_size_kb = file_bytes.len() / 1024;
 
-    info!("Uploading {} ({} KB) -> {}", file_path.display(), file_size_kb, upload_id);
+    info!(
+        "Uploading {} ({} KB) -> {}",
+        file_path.display(),
+        file_size_kb,
+        upload_id
+    );
     client
         .put(&upload_url)
         .body(file_bytes)
@@ -242,10 +243,7 @@ pub async fn submit_result_with_retries(
         match submit_result(website_url, token, input).await {
             Ok(id) => return Ok(id),
             Err(e) => {
-                error!(
-                    "Submit result attempt {}/{} failed: {}",
-                    attempt, limit, e
-                );
+                error!("Submit result attempt {}/{} failed: {}", attempt, limit, e);
                 last_err = Some(e);
                 if attempt < limit {
                     // TODO: Implement incremental cooldown

--- a/match_controller/src/matches/sources/aiarena_api/mod.rs
+++ b/match_controller/src/matches/sources/aiarena_api/mod.rs
@@ -188,15 +188,18 @@ impl MatchSource for HttpApiSource {
         // Try GraphQL submission first
         debug!("Attempting to submit result with GraphQL");
         match self
-            .submit_result_with_graphql(game_result, Some(LogsAndReplays {
-                upload_url: upload_url.clone(),
-                bot1_name: bot1_name.clone(),
-                bot2_name: bot2_name.clone(),
-                bot1_dir: bot1_dir.clone(),
-                bot2_dir: bot2_dir.clone(),
-                arenaclient_log: arenaclient_log.clone(),
-                replay_file: replay_file.clone(),
-            }))
+            .submit_result_with_graphql(
+                game_result,
+                Some(LogsAndReplays {
+                    upload_url: upload_url.clone(),
+                    bot1_name: bot1_name.clone(),
+                    bot2_name: bot2_name.clone(),
+                    bot1_dir: bot1_dir.clone(),
+                    bot2_dir: bot2_dir.clone(),
+                    arenaclient_log: arenaclient_log.clone(),
+                    replay_file: replay_file.clone(),
+                }),
+            )
             .await
         {
             Ok(()) => return Ok(()),

--- a/match_controller/src/matches/sources/aiarena_api/mod.rs
+++ b/match_controller/src/matches/sources/aiarena_api/mod.rs
@@ -1,3 +1,5 @@
+pub mod graphql;
+
 use crate::matches::sources::file_source::errors::SubmissionError;
 use crate::matches::sources::{LogsAndReplays, MatchSource};
 use async_trait::async_trait;
@@ -19,6 +21,8 @@ use tracing::{debug, info};
 
 pub struct HttpApiSource {
     api: AiArenaApiClient,
+    website_url: String,
+    token: String,
 }
 
 impl HttpApiSource {
@@ -33,7 +37,11 @@ impl HttpApiSource {
                 &settings.base_website_url, e
             )
         })?;
-        Ok(Self { api })
+        Ok(Self {
+            api,
+            website_url: settings.base_website_url.clone(),
+            token: api_token.clone(),
+        })
     }
     async fn download_map(
         &self,
@@ -47,6 +55,69 @@ impl HttpApiSource {
         let map_path = base_dir().join("maps").join(format!("{map_name}.SC2Map"));
         let mut file = tokio::fs::File::create(map_path).await?;
         Ok(file.write_all(&map_bytes).await?)
+    }
+
+    async fn upload_file(&self, path: &PathBuf) -> Result<String, SubmissionError> {
+        if path.exists() {
+            graphql::upload_file_with_retries(&self.website_url, &self.token, path, 60)
+                .await
+                .map_err(|e| {
+                    error!("Failed to upload {}: {}", path.display(), e);
+                    SubmissionError::LogsAndReplaysNull
+                })
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    pub async fn submit_result_with_graphql(
+        &self,
+        game_result: &AiArenaGameResult,
+        logs_and_replays: Option<LogsAndReplays>,
+    ) -> Result<(), SubmissionError> {
+        if logs_and_replays.is_none() {
+            return Err(SubmissionError::LogsAndReplaysNull);
+        }
+        let LogsAndReplays {
+            bot1_dir,
+            bot2_dir,
+            arenaclient_log,
+            replay_file,
+            ..
+        } = logs_and_replays.unwrap();
+
+        let replay_id = self.upload_file(&replay_file).await?;
+        let arenaclient_log_id = self.upload_file(&arenaclient_log).await?;
+        let bot1_data_id = self.upload_file(&bot1_dir.join("data.zip")).await?;
+        let bot2_data_id = self.upload_file(&bot2_dir.join("data.zip")).await?;
+        let bot1_log_id = self.upload_file(&bot1_dir.join("logs.zip")).await?;
+        let bot2_log_id = self.upload_file(&bot2_dir.join("logs.zip")).await?;
+
+        let input = graphql::SubmitResultInput {
+            match_id: graphql::encode_match_id(&game_result.match_id.to_string()),
+            result_type: game_result.result.to_string(),
+            game_steps: game_result.game_steps,
+            bot1_avg_step_time: game_result.bot1_avg_step_time.unwrap_or(0.0),
+            bot2_avg_step_time: game_result.bot2_avg_step_time.unwrap_or(0.0),
+            bot1_tags: game_result.bot1_tags.clone().unwrap_or_default(),
+            bot2_tags: game_result.bot2_tags.clone().unwrap_or_default(),
+            replay_file: replay_id,
+            arenaclient_log: arenaclient_log_id,
+            bot1_data: bot1_data_id,
+            bot2_data: bot2_data_id,
+            bot1_log: bot1_log_id,
+            bot2_log: bot2_log_id,
+        };
+
+        // TODO: Increase retries to 60 before old API is retired
+        graphql::submit_result_with_retries(&self.website_url, &self.token, &input, 3)
+            .await
+            .map_err(|e| {
+                error!("Failed to submit result via GraphQL: {}", e);
+                SubmissionError::LogsAndReplaysNull
+            })?;
+
+        Ok(())
     }
 }
 
@@ -113,6 +184,25 @@ impl MatchSource for HttpApiSource {
                 error!("Error uploading to cache server: {}", e);
             }
         }
+
+        // Try GraphQL submission first
+        debug!("Attempting to submit result with GraphQL");
+        match self
+            .submit_result_with_graphql(game_result, Some(LogsAndReplays {
+                upload_url: upload_url.clone(),
+                bot1_name: bot1_name.clone(),
+                bot2_name: bot2_name.clone(),
+                bot1_dir: bot1_dir.clone(),
+                bot2_dir: bot2_dir.clone(),
+                arenaclient_log: arenaclient_log.clone(),
+                replay_file: replay_file.clone(),
+            }))
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(e) => error!("GraphQL submission failed: {:?}", e),
+        }
+
         while attempt < 60 {
             debug!("Attempting to submit result. Attempt number: {}", attempt);
 

--- a/match_controller/src/matches/sources/aiarena_api/mod.rs
+++ b/match_controller/src/matches/sources/aiarena_api/mod.rs
@@ -59,7 +59,8 @@ impl HttpApiSource {
 
     async fn upload_file(&self, path: &PathBuf) -> Result<String, SubmissionError> {
         if path.exists() {
-            graphql::upload_file_with_retries(&self.website_url, &self.token, path, 60)
+            // TODO: Increase retries to 60 before old API is retired
+            graphql::upload_file_with_retries(&self.website_url, &self.token, path, 3)
                 .await
                 .map_err(|e| {
                     error!("Failed to upload {}: {}", path.display(), e);


### PR DESCRIPTION
Match controller uses GraphQL to submit match results. All ZIP files are uploaded directly to AWS S3. If GraphQL requests to submit a match result fails in 3 attempts then it falls back to using the old API. This ensures that there is a problem with the GraphQL interaction the match results will not be lost.

Successfully tested with:
* https://aiarena.net/matches/4780263/
* https://aiarena.net/matches/4779010/
